### PR TITLE
Allow custom range patterns in `range` method + fix when range is “sameDay”

### DIFF
--- a/HumanDates.php
+++ b/HumanDates.php
@@ -58,10 +58,11 @@ class HumanDates
   /**
    * Format a daterange as human readable date string
    */
-  function range($from, $to): string
+  function range($from, $to, $patterns = null): string
   {
     $from = $this->timestamp($from);
     $to = $this->timestamp($to);
+    $this->setPatterns($patterns);
 
     if (date("Ymd", $from) === date("Ymd", $to)) $pattern = 'sameDay';
     elseif (date("Ym", $from) === date("Ym", $to)) $pattern = 'sameMonth';
@@ -69,11 +70,19 @@ class HumanDates
     else $pattern = 'default';
 
     $pattern = $this->patterns[$pattern];
-    $pieces = array_filter([
-      $this->getString($from, $pattern[0]),
-      $this->getString($to, $pattern[2]),
-    ]);
-    return implode($pattern[1], $pieces);
+    if(count($pattern) == 3) {
+      $pieces = array_filter([
+        $this->getString($from, $pattern[0]),
+        $this->getString($to, $pattern[2]),
+      ]);
+      $range = implode($pattern[1], $pieces);
+    } else {
+      $range = $this->getString($from, $pattern[0]);
+    }
+
+    $this->patterns = self::rangePatterns;
+
+    return $range;
   }
 
   /**

--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ echo $dates->range("2023-01-01", "2023-01-03", [
 ]);
 ```
 
+Note that this will set the patterns for this single request only! If you want to modify the globally used patterns you can do this:
+
+```php
+echo $dates->setPatterns(...)->range(...);
+```
+
 ## Setting Locales
 
 You can set the locale for date formatting either globally for the current `HumanDates` instance or on a per-format basis.


### PR DESCRIPTION
Hi @BernhardBaumrock,

Thanks for sharing this library!

I recently started to use it and faced two small issues:

- the one mentioned in this issue #1, where the [README](https://github.com/baumrock/HumanDates#formatting-a-date-range) says you can use custom range patterns when calling `HumanDates::range()`
- when the range is “sameDay” the `$pattern` array only has one value and thus the implode call is triggering an error in PHP 8.0+ (passing `null` is deprecated)

This PR fixes both but maybe you want to have a look first to make sure you would have done it this way or not?

Best,
Romain